### PR TITLE
fix a typo telegram -> messenger in migration template

### DIFF
--- a/packages/create-app/src/template/src/migrations/0-init-app.ts.t.ts
+++ b/packages/create-app/src/template/src/migrations/0-init-app.ts.t.ts
@@ -13,7 +13,7 @@ import Telegram from '@machinat/telegram';`}${when(platforms.includes('line'))`
 import Line from '@machinat/line';`}
 
 const {
-  DOMAIN,${when(platforms.includes('telegram'))`
+  DOMAIN,${when(platforms.includes('messenger'))`
   MESSENGER_PAGE_ID,
   MESSENGER_APP_ID,
   MESSENGER_APP_SECRET,


### PR DESCRIPTION
Some env variables  are missing here after the file generated so I believe this's a typo.